### PR TITLE
User können wenn angemeldet auf die Accountsettings zugreifen und ihr Konto löschen

### DIFF
--- a/CampusConnect.Server/Controllers/UserController.cs
+++ b/CampusConnect.Server/Controllers/UserController.cs
@@ -107,10 +107,10 @@ namespace CampusConnect.Server.Controllers
         }
 
 
-        [HttpDelete("{userId}")]
-        public async Task<IActionResult> DeleteUser(int userId)
+        [HttpDelete("{loginName}")]
+        public async Task<IActionResult> DeleteUser(string loginName)
         {
-            var user = await _context.Users.FirstOrDefaultAsync(u => u.UserId == userId);
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.LoginName == loginName);
 
             if (user is null)
             {

--- a/campusconnect.client/src/app/app-routing.module.ts
+++ b/campusconnect.client/src/app/app-routing.module.ts
@@ -32,11 +32,13 @@ const routes: Routes = [
     },
     {
         path: 'accountsettings',
-        component: AccountSettingsComponent
+        component: AccountSettingsComponent,
+        canActivate: [AuthGuard]
     },
     {
         path: 'emailsettings',
-        component: EmailSettingsComponent
+        component: EmailSettingsComponent,
+        canActivate: [AuthGuard]
     },
     {
         path: "adminpanel",

--- a/campusconnect.client/src/app/delete-account/delete-account.component.html
+++ b/campusconnect.client/src/app/delete-account/delete-account.component.html
@@ -6,7 +6,7 @@
   <button mat-raised-button class="cancel-button" (click)="closeDialog()">
     abbrechen
   </button>
-  <button mat-raised-button class="confirm-button" (click)="confirmDeletion(8)">  <!-- UserID bisher nur händisch anzugeben -->
+  <button mat-raised-button class="confirm-button" (click)="confirmDeletion()">
     bestätigen
   </button>
 </div>

--- a/campusconnect.client/src/app/delete-account/delete-account.component.ts
+++ b/campusconnect.client/src/app/delete-account/delete-account.component.ts
@@ -3,6 +3,7 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { UserService } from '../services/user.service';
 import { Router } from '@angular/router';
 import { baseApiRoute } from '../app-routing.module';
+import { AuthorizationService } from '../services/authorization.service';
 
 @Component({
   selector: 'app-delete-account',
@@ -12,18 +13,17 @@ import { baseApiRoute } from '../app-routing.module';
 export class DeleteAccountComponent {
 
   dialog: MatDialogRef<DeleteAccountComponent>;   // speichert das geöffnete Dialogfenster
-  userService: UserService;                       // UserService Instanz
   router: Router;                                 // Router-Instanz zum Navigieren zur Homepage nach Löschvorgang
 
   /* bekommt das geöffnete Dialogfenster übergeben */
   constructor(
     private dialogRef: MatDialogRef<DeleteAccountComponent>, 
     private us: UserService,
-    private r: Router
+    private r: Router,
+    private auth: AuthorizationService
   ) 
   {
     this.dialog = dialogRef;
-    this.userService = us;
     this.router = r;
   }
   /* Schließt das Dialogfenster */
@@ -32,18 +32,24 @@ export class DeleteAccountComponent {
     this.dialog.close();
   }
 
-  confirmDeletion(userID: number) 
+  confirmDeletion() 
   {
-    this.userService.deleteUser(userID).subscribe(
-      response => { 
-        console.log("Eintrag gelöscht!"); 
-        this.router.navigate(['/'])
-      },
-      error => { 
-        console.error("Fehler beim Löschen"); 
-      }
-    );
+    const loginName = this.auth.getUserName();
+
+    if (loginName) {
+      this.us.deleteUser(loginName).subscribe(
+        (response) => 
+        {
+          console.log("User deleted.");
+          this.r.navigate(['/']);
+        },
+        (error) => 
+        {
+          console.log("Deletion failed.")
+        })
+    }
     this.closeDialog();
+    localStorage.removeItem("jwt");
   }
 
 }

--- a/campusconnect.client/src/app/services/user.service.ts
+++ b/campusconnect.client/src/app/services/user.service.ts
@@ -37,8 +37,8 @@ export class UserService {
         return this.httpClient.get<boolean>(baseApiRoute + "user/exists/" + loginName);
     }
 
-    public deleteUser(userID: number): Observable<void> {
-        return this.httpClient.delete<void>(baseApiRoute + "user/" + userID);
+    public deleteUser(loginName: string): Observable<void> {
+        return this.httpClient.delete<void>(baseApiRoute + "user/" + loginName);
     }
 
     public getUserById(userId: number): Observable<UserEntity> {


### PR DESCRIPTION
Funktionen im UserService und UserController von ID auf LoginName umgestellt. LoginName wird aus dem Token gezogen. Konto- und Email-Einstellungen sind nur noch erreichbar wenn eingeloggt. Token wird aus LocalStorage entfernt nach Kontolöschung.